### PR TITLE
Remove dead Google Docs link

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -12,7 +12,6 @@ The document is split into two major sections: [Content](#content) and [Code](#c
 ### <a name="content"></a>Content
 
 #### Posts
-* [Programming Bitcoin Transaction Scripts](https://docs.google.com/document/d/1D_gi_7Sf9sOyAHG25cMpOO4xtLq3iJUtjRwcZXFLv1E/edit) (Kofler)
 * [Developer’s Introduction to Bitcoin](http://bitcoinmagazine.com/9249/developers-introduction-bitcoin/) (Buterin)
 * [How Bitcoin Works Under the Hood](http://www.imponderablethings.com/2013/07/how-bitcoin-works-under-hood.html) (Driscoll)
 * [Bitcoin Developer Guide](http://bitcoindev.us.to/en/developer-guide)


### PR DESCRIPTION
The "Programming Bitcoin Transaction Scripts" resource links to a deleted Google Doc (see screenshot):

![Screen Shot 2022-06-12 at 07 24 40](https://user-images.githubusercontent.com/788415/173230988-7cb97e64-02cf-4e51-acd5-2c0dc7690b4f.png)

If somebody has a working link, I would love to replace this dead link with a working one. Otherwise, I think removing it is probably best.